### PR TITLE
Date formatter now includes year

### DIFF
--- a/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
@@ -48,7 +48,8 @@
             {
                 weekday: dateStringType,
                 month: dateStringType,
-                day: 'numeric'
+                day: 'numeric',
+                year: 'numeric'
             }
         );
     };


### PR DESCRIPTION
This includes the year in the ride details view. This also includes the year in each date header (yellow bar above each date), which we can adjust if needed.